### PR TITLE
Use secrets instead of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ I'll do that as a separate set of instructions later on. I essentially followed
 the directions from [OpenFaas Deployment] and used the awesome [Arkade] CLI
 installer for Kubernetes applications, plus some of the linked blog posts.
 
+### OpenFaaS MinIO S3 Credentials
+
+To access files from the bucket the function requires credentials to
+authenticate with MinIO. These need to be added as a secret in the `openfaas-fn`
+namespace so that it is available for use by the function. When the function is
+deployed the secrets will be mounted as files to
+`/var/openfaas/secrets/website-access-key-id` and
+`/var/openfaas/secrets/website-secret-access-key` and the values can be read by
+the function. See [OpenFaas Using secrets] for more information.
+
+```plain
+kubectl create secret generic website-access-key-id \
+  --from-literal website-access-key-id="GNxxxxxxx87" \
+  --namespace openfaas-fn
+
+kubectl create secret generic website-secret-access-key \
+  --from-literal website-secret-access-key="9BTxxxxxxxxxxxxxxxxxxxD4T" \
+  --namespace openfaas-fn
+```
+
 ## Private Docker Registry
 
 When deploying functions from a private registry OpenFaaS needs the credentials
@@ -173,9 +193,9 @@ $ faas-cli deploy \
   --env S3_HTTP_LOG_LEVEL=debug \
   --env S3_HTTP_ENDPOINT=s3.mydomain.io \
   --env S3_HTTP_BUCKET_NAME=website \
-  --env S3_HTTP_ACCESS_KEY_ID=AKIYYYXXZZ7XXXZZ \
-  --env S3_HTTP_SECRET_ACCESS_KEY=wXXzzWWI/K7XXHM/bPxRfiCYDEXXQQQ \
-  --env S3_HTTP_DEFAULT_PAGE=index.html
+  --env S3_HTTP_DEFAULT_PAGE=index.html \
+  --secret website-access-key-id \
+  --secret website-secret-access-key
 
 Deployed. 202 Accepted.
 URL: https://gateway.mydomain.io/function/minio-s3-http-server

--- a/README.md
+++ b/README.md
@@ -14,13 +14,44 @@ I'll do that as a separate set of instructions later on. I essentially followed
 the directions from [OpenFaas Deployment] and used the awesome [Arkade] CLI
 installer for Kubernetes applications, plus some of the linked blog posts.
 
-### OpenFaaS MinIO S3 Credentials
+## OpenFaaS and MinIO Credentials
 
 To access files from the bucket the function requires credentials to
-authenticate with MinIO. These need to be added as a secret in the `openfaas-fn`
-namespace so that it is available for use by the function. When the function is
-deployed the secrets will be mounted as files to
-`/var/openfaas/secrets/website-access-key-id` and
+authenticate with MinIO. One option is to use a Service Account.
+
+### MinIO Service Account
+
+The MinIO user management [Create Service Accounts] documentation provides
+details on creating a service account. This process will create the access key
+and secret access key that can be provided as secrets to the OpenFaaS function.
+
+The below IAM policy can be used to grant the service account access to the S3
+bucket. This is named `website` in this example and must match the one specified
+for the `S3_HTTP_BUCKET_NAME` environment variable of the function.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::website"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:ListMultipartUploadParts"],
+      "Resource": ["arn:aws:s3:::website/*"]
+    }
+  ]
+}
+```
+
+### OpenFaaS Secret Credentials
+
+These secrets need to be added in the `openfaas-fn` namespace so that they are
+available for use by the function. When the function is deployed the secrets
+will be mounted as files to `/var/openfaas/secrets/website-access-key-id` and
 `/var/openfaas/secrets/website-secret-access-key` and the values can be read by
 the function. See [OpenFaas Using secrets] for more information.
 
@@ -187,7 +218,7 @@ credentials saved for admin https://gateway.mydomain.io
 
 ```plain
 $ faas-cli deploy \
-  --image registry.mydomain.io/openfaas/minio-s3-http-server:0.1.0 \
+  --image registry.mydomain.io/openfaas/minio-s3-http-server:latest \
   --name minio-s3-http-server \
   --env S3_HTTP_DEBUG=true \
   --env S3_HTTP_LOG_LEVEL=debug \
@@ -260,6 +291,8 @@ faas-cli remove minio-s3-http-server
 [![MIT license]](https://lbesson.mit-license.org/)
 
 [arkade]: https://github.com/alexellis/arkade
+[create service accounts]:
+  https://docs.min.io/minio/k8s/tutorials/user-management.html#create-service-accounts
 [docker buildx]:
   https://docs.docker.com/engine/reference/commandline/buildx_build/
 [go - dependencies]: https://docs.openfaas.com/cli/templates/#go-go-dependencies

--- a/minio-s3-http-server.yml
+++ b/minio-s3-http-server.yml
@@ -13,3 +13,8 @@ functions:
       S3_HTTP_DEBUG: true
       S3_HTTP_LOG_LEVEL: debug
       S3_HTTP_ENDPOINT: s3.mydomain.io
+      S3_HTTP_BUCKET_NAME: website
+      S3_HTTP_DEFAULT_PAGE: index.html
+    secrets:
+      - website-access-key-id
+      - website-secret-access-key


### PR DESCRIPTION
Use secrets instead of environment variables for MinIO access key and secret access key

The access key and secret access key values have been moved from environment variables into secrets.
OpenFaaS will mount secrets as files into the container at runtime. The keys can be retrieved by reading them
from these files.